### PR TITLE
fixed navbar and scrolling issue

### DIFF
--- a/funwithphysics/src/Components/Home/Home.js
+++ b/funwithphysics/src/Components/Home/Home.js
@@ -8,11 +8,9 @@ import Navbar from "../Navbar/Navbar";
 import { Context } from "../../App";
 
 const Home = () => {
-  const [loading, setloading] = useState(true);
   const { dispatch } = useContext(Context);
   useEffect(() => {
     setTimeout(() => {
-      setloading(false);
       const user = JSON.parse(localStorage.getItem("user"));
       if (user !== null) {
         dispatch({
@@ -86,12 +84,10 @@ const bookReaderStyle = {
       <LearnMore />
       <Footer />
       {/* <!-- Back to top button --> */}
-      {!loading && (
-        <button className="gotopbtn" onClick={scroll}>
+        <button className="gotopbtn" onClick={() => scroll()}>
           {" "}
           <i className="fas fa-arrow-up"></i>{" "}
         </button>
-      )}
     </React.Fragment>
   );
 };

--- a/funwithphysics/src/Components/Navbar/Navbar.css
+++ b/funwithphysics/src/Components/Navbar/Navbar.css
@@ -46,6 +46,14 @@
   border: none;
 }
 
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 10;
+}
+
 /* HAMBURGER ICON CSS */
 .menu-btn {
   position: relative;


### PR DESCRIPTION
## Related Issue

- Made the navbar sticky, and resolved the page scrolling to the top automatically

Fixes: [#358 ](https://github.com/Tech-N-Science/FunwithScience/issues/358)

#### Describe the changes you've made

Added a navbar class in `funwithphysics/src/Components/Navbar/Navbar.css` and made it fixed.
Because of the setTimeout, after 4 seconds the loading is set to false which causes the page to scroll to top so removed the loading state in `funwithphysics/src/Components/Home/Home.js`.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| ![Screenshot 2022-02-07 at 11 13 24 AM](https://user-images.githubusercontent.com/74371312/152731155-6d2ff9a6-18e7-4cc7-b7fc-3302f9c66f90.png) | ![Screenshot 2022-02-07 at 11 13 07 AM](https://user-images.githubusercontent.com/74371312/152731287-d024d1a0-400d-4c2e-8c6e-a8aeffd6a2d8.png) |




