### PR TITLE
Changed Examples styling of maths calculators

### DIFF
--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -200,7 +200,7 @@ function Calculator() {
         <br />,
         `For D < 0 the roots do not exist, or the roots are imaginary.`,
       ],
-      example: [
+      example1: [
         "Let the quadratic equation be x²-5x+6 = 0",
         <br />,
         "Comparing the equation with the general form ax² + bx + c = 0 gives ",
@@ -211,8 +211,9 @@ function Calculator() {
         <br />,
         "Substitute the values in the quadratic formula",
         <br />,
-        "x₁ = (-b + √b²-4ac)/2a",
-        <br />,
+        "x₁ = (-b + √b²-4ac)/2a",        
+      ],
+      example2: [
         "⇒ (5 + 1)/2",
         <br />,
         " = 3",

--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -169,7 +169,7 @@ function Calculator() {
       process: [
         "To find x raised to the power n we need to multiply x with itself n times.",
       ],
-      example: [
+      example1: [
         "2 raised to the power 3 is simply 2*2*2=8",
         <br />,
         "Square Root of 16 is a number(say a) such that a*a=16 ,which on computation gives 4.",

--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -136,7 +136,7 @@ function Calculator() {
         "A complex number Z = x + iy is a purely real if its imaginary part is 0, i.e. Im(z) = 0 and purely imaginary if its real part is 0 i.e. Re (z) = 0.",
         <br />,
       ],
-      example: [
+      example1: [
         "z₁ = 2 + 3i is first complex number equation, ",
 
         "z₂ = 5 + 10i is second complex number equation",
@@ -147,7 +147,8 @@ function Calculator() {
         <br />,
         <b>E.g. </b>,
         "Polar Form: √17(cos(1.816) + isin(1.816))",
-        <br />,
+      ],
+      example2: [
         "For Cartesian Form:",
         <br />,
         "z  =  (√17 × cos(1.816))  +  i(√17 × sin(1.816))",

--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -73,7 +73,7 @@ function Calculator() {
         "To find the Arithmetic progression of nᵗʰ term, we use the formula a + d * (n-1) where, 'a' is the first term of the series and 'd' is the common difference between any two numbers in the series found by taking the difference. To find the Geometric progression of nᵗʰ term, we use the formula a + r ⁽ⁿ⁻¹⁾ where, 'a' is the first term of the series and 'r' is the common difference between any two numbers in the series found by taking the ratio.",
         <br />,
       ],
-      example: [
+      example1: [
         "2,4,6,8.. is an AP because difference between any two consecutive terms in the series (common difference) is same (4 – 2 = 6 – 4 = 8 – 6 = 2).",
         <br />,
         "If ‘a’(2) is the first term and ‘d’(2) is the common difference,",
@@ -82,6 +82,8 @@ function Calculator() {
         <br />,
         "5th term of the AP = 2 + (5-1) * 2 = 10",
         <br />,
+      ],
+      example2: [
         <b>E.g. </b>,
         "2,4,8,16 is a GP because ratio of any two consecutive terms in the series (common difference) is same (4 / 2 = 8 / 4 = 16 / 8 = 2)",
         <br />,

--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -103,16 +103,15 @@ function Calculator() {
 
         <br />,
       ],
-      example: [
+      example1: [
         "Numbers given: 20 30 60 20 10 40 80 90",
         <br />,
         "Mean = Sum of all items/Total no. of items = 350/8 = 43.75",
         <br />,
-        "Since total number of items is 6(even), Median = (n / 2)th = 3rd item = 30",
-        <br />,
         "Mode = 20 (as 20 occured most number of times in the given set of numbers)",
-        <br />,
-        "Standar deviation is calculated by deviations of each data point from the mean, and square the result of each whole divided by total number of samples minus 1.Hence it is , = 29.73",
+      ],
+      example2: [
+        "Standard deviation is calculated by deviations of each data point from the mean, and square the result of each whole divided by total number of samples minus 1.Hence it is , = 29.73",
         <br />,
         "Variance is square of standard deviation.Hence it is = 883.92",
         <br />,

--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -28,7 +28,7 @@ function Calculator() {
         "To calculate combinations, we will use the formula nCr = n! / (r! * (n - r)!), where n represents the number of items, and r represents the number of items being chosen at a time.",
         <br />,
       ],
-      example: [
+      example1: [
         <span>
            <b>How many different teams(each having 5 members) can be formed from 12 students?</b>
            <br/>
@@ -42,6 +42,8 @@ function Calculator() {
            12 C 5 = 12! / [ (12 - 5)!5! ] = 792
            <br/>
         </span>,
+      ],
+      example2: [
         <span>
           <b>How many 3 letter words can we make with the letters in the word ABCD(without repetition)?</b>
           <br/>
@@ -54,8 +56,7 @@ function Calculator() {
           <br/>
           The number of words is given by
           4 P 3 = 4! / (4 - 3)! = 24
-        </span>
-
+        </span>,
       ],
     },
    
@@ -1546,7 +1547,15 @@ function Calculator() {
         </div>
         <div className="Calculator__example">
           <h3>Example</h3>
-          <p>{details.example}</p>
+          <div className="row">
+            <div className="col-sm-6 col-lg-6 ">
+              <p>{details.example1}</p>
+            </div>
+
+            <div className="col-sm-6 col-lg-6 ">
+              <p>{details.example2}</p>
+            </div>
+          </div>
         </div>
         <div className="Calculator__calc">
           <h3>{details.topic} Calculator</h3>

--- a/funwithphysics/src/Components/Geometry/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Geometry/Topic/Calculator.js
@@ -113,7 +113,7 @@ function Calculator() {
         "To find the equation of an ellipse in the standard form with center (h,k) we need two vertices and foci",
         <br />,
       ],
-      example: [
+      example1: [
         "Find the equation of ellipse that has vertices (-2,-8) and (-2,2) and foci (-2,-7) and (-2,1),",
         <br />,
         "First we find out the center(h,k) which is halfway between the vertices,(-2,-8) and (-2,2).",
@@ -124,12 +124,15 @@ function Calculator() {
         <br />,
         "Next we find a².The length of major axis is 2a.We solve for 'a' by finding the distance between y-coordinates of vertices: ",
         <br />,
-        "2a = 2 - (-8)",
+        "2a = 2 - (-8)",        
         <br />,
         "a = 5 So, a² = 25",
         <br />,
         "Now we find c². The foci are given as (h,k-c)=(-2,-7) and (h,k+c)=(-2,1).We substitute k=-3 in either of these points",
-        <br />,
+        
+        
+      ],
+      example2: [
         "k+c=1",
         <br />,
         "-3+c=1",

--- a/funwithphysics/src/Components/Geometry/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Geometry/Topic/Calculator.js
@@ -128,8 +128,7 @@ function Calculator() {
         <br />,
         "a = 5 So, a² = 25",
         <br />,
-        "Now we find c². The foci are given as (h,k-c)=(-2,-7) and (h,k+c)=(-2,1).We substitute k=-3 in either of these points",
-        
+        "Now we find c². The foci are given as (h,k-c)=(-2,-7) and (h,k+c)=(-2,1).We substitute k=-3 in either of these points",        
         
       ],
       example2: [
@@ -156,14 +155,16 @@ function Calculator() {
         "To find the standard equation of a circle, we will be needing the coordinates of the center of the circle (h,k) and its radius (r).",
         <br />,
       ],
-      example: [
+      example1: [
         <b>E.g. </b>,
         "Find the equation of a circle if point (1,2) is the center of the circle and it’s radius is equal to 4 cm.",
         <br />,
         <b>Solution: </b>,
         <br />,
         "(x-1)²+(y-2)² = 4²",
-        <br />,
+        
+      ],      
+      example2: [
         "(x²−2x+1)+(y²−4y+4) =16",
         <br />,
         <b>x²+y²−2x−4y-11 = 0 </b>,

--- a/funwithphysics/src/Components/Geometry/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Geometry/Topic/Calculator.js
@@ -58,7 +58,7 @@ function Calculator() {
         "(x-α)² = 4a(y-β) whose vertex is (α,β) and axis is parallel to the y-axis",
         <br />,
       ],
-      example: [
+      example1: [
         "Find the equation of the parabola given the vertex(2,3) and point(-1,6).",
         <br />,
         <b>Solution: </b>,
@@ -78,7 +78,9 @@ function Calculator() {
         "where (h,k) is the vertex.",
         <br />,
         "Substituting the given vertex in the above formula. ",
-        <br />,
+        
+      ],
+      example2: [
         "y = a(x-2)²+3",
         <br />,
         "Knowing that (-1,6) lies on the parabola we can solve for 'a' by, ",

--- a/funwithphysics/src/Components/Geometry/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Geometry/Topic/Calculator.js
@@ -21,13 +21,14 @@ function Calculator() {
         "To find the equation of line using the two-point formula we will be needing co-ordinates of two points.",
         <br />,
       ],
-      example: [
+      example1: [
         "Find the equation of a line passing through (-2, 4) and (3, 1).",
         <br />,
         <b>Solution: </b>,
 
         "Substituting the coordinates in the above two-point formula",
-        <br />,
+      ],
+      example2: [
         "(1-4)x + (-2-3)y - (-2*1) + (3*4) = 0",
         <br />,
         "-3x + (-5)y - (-2) + (12) = 0",
@@ -1285,8 +1286,16 @@ function Calculator() {
           <p>{details.process}</p>
         </div>
         <div className="Calculator__example">
-          <h3>Example</h3>
-          <p>{details.example}</p>
+          <h3>Example</h3>          
+          <div className="row">
+            <div className="col-sm-6 col-lg-6 ">
+              <p>{details.example1}</p>
+            </div>
+
+            <div className="col-sm-6 col-lg-6 ">
+              <p>{details.example2}</p>
+            </div>
+          </div>
         </div>
         <div className="Calculator__calc">
           <h3>{details.topic} Calculator</h3>


### PR DESCRIPTION
Fixes: #405 

#### Describe the changes you've made

changed styling rules of an example of every maths calculator into two different columns and half example will break into left and half shifted into the right.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


##Screenshots

![image](https://user-images.githubusercontent.com/25982821/154320668-f5c70ddf-dd6a-4af1-ae97-e347e3ed9186.png)

Every other calculators example styling will be the same


