### PR TITLE
Revert and fix prev PR

### DIFF
--- a/funwithphysics/src/Components/Home/Home.js
+++ b/funwithphysics/src/Components/Home/Home.js
@@ -10,9 +10,11 @@ import AboutUSImage from "../../Images/about-us-image.svg";
 
 const Home = () => {
   const [loading, setloading] = useState(true);
+  const [visible,setvisible] = useState(false)
   const { dispatch } = useContext(Context);
 
   useEffect(() => {
+    setvisible(true)
     setTimeout(() => {
       setloading(false);
       const user = JSON.parse(localStorage.getItem("user"));
@@ -35,7 +37,14 @@ const Home = () => {
   
   return (
     <React.Fragment>
-      <Navbar />
+            {/* <!-- Back to top button --> */}
+            {visible && (
+        <button className="gotopbtn" onClick={scroll}>
+          {" "}
+          <i className="fas fa-arrow-up"></i>{" "}
+        </button>
+      )}
+      <Navbar fromhome = "true" />
       <Helmet>
         <title>Fun With Science - Tech N Science </title>
         <meta
@@ -114,13 +123,7 @@ const Home = () => {
       </div>
       <LearnMore />
       <Footer />
-      {/* <!-- Back to top button --> */}
-      {!loading && (
-        <button className="gotopbtn" onClick={scroll}>
-          {" "}
-          <i className="fas fa-arrow-up"></i>{" "}
-        </button>
-      )}
+
     </React.Fragment>
   );
 };

--- a/funwithphysics/src/Components/Navbar/Navbar.css
+++ b/funwithphysics/src/Components/Navbar/Navbar.css
@@ -1,3 +1,4 @@
+
 .fa-book {
   color: #0a0a0a;
   margin-right: 10px;

--- a/funwithphysics/src/Components/Navbar/Navbar.js
+++ b/funwithphysics/src/Components/Navbar/Navbar.js
@@ -8,7 +8,7 @@ import { FiPlus, FiMinus } from 'react-icons/fi';
 import { Accordion, Card } from 'react-bootstrap';
 import logo from '../../Images/Logo/logo.webp';
 import { Context } from '../../App';
-const Navbar = () => {
+const Navbar = (props) => {
   const { state, dispatch } = useContext(Context);
   const [clicked, setClicked] = useState(false);
   const user = localStorage.getItem('user');
@@ -20,13 +20,10 @@ const Navbar = () => {
     setClicked(index);
   };
 
-    useEffect(() => {
-      
-        window.scrollTo(0, 0);
-       
-     
-    }, );
-
+  if (typeof(props.fromhome) === "undefined"){
+    console.log("yes",props.fromhome)
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
 
   const menuBtnRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -49,7 +46,7 @@ const Navbar = () => {
   };
   return (
     <React.Fragment>
-      <nav className='navbar navbar-expand-lg navbar-light bg-light pt-3'>
+      <nav className='navbar navbar-expand-lg navbar-light bg-light pt-3' style = {{position:'sticky',top:'0','z-index':'100'}}>
         <p className='navbar-brand'>
           <button
             className='navbar-toggler'


### PR DESCRIPTION
Issue #358

Fixes: #[issue number that will be closed through this PR]
It fixes issue https://github.com/Tech-N-Science/FunwithScience/issues/358

Describe the changes you've made
There was bug in home page which caused it to scroll up automatically after certain seconds.It was basically due to
=> Onclick function being sent directly instead of sending it as a event.
=> Another important reason was useeffect hook in navbar page which scrolled the page during render and navbar itself was rendered only after 4 seconds delay caused by settimeout in homepage's useeffect.Both together made the page go up after 4 seconds
Basically issue was not from calculator button / go top button.After solving the above causes , the problem was fixed.

To fix the navbar permanently even after scrolling , styles changes were made and most importantly position of navbar was changed to "sticky".

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [ x] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have made corresponding changes to the documentation.
- [x ] My changes generate no new warnings.


