### PR TITLE
fix: Add solution part to different calculators in Oscillation section

### DIFF
--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -227,7 +227,7 @@ function ShmCalculator() {
               className="select-custom-res"
               onChange={(e) => {
                 setChoice(e.target.value);
-                setResult(false);
+                setResult(null);
                 setShowSolution(false)}
               }
             >
@@ -361,6 +361,7 @@ function ShmCalculator() {
         case "pendulum":
           if(length !== null){
             res = 2 * pi * Math.sqrt(length / g);
+            setShowSolution(true);
           }           
           else {
             setShowModal(true);
@@ -370,6 +371,7 @@ function ShmCalculator() {
         case "spring-mass":
           if(mass !== null && springConst !== null){
             res = 2 * pi * Math.sqrt(mass / springConst);
+            setShowSolution(true);
           }          
           else {
             setShowModal(true);
@@ -399,7 +401,7 @@ function ShmCalculator() {
     const choice_data = () => {
       if (choiceOsc === "shm")
         return {
-          name: "General Eqn: SHM",
+          name: "SHM",
           mainunit: "m",
           quantities: [
             "Amplitude",
@@ -410,6 +412,14 @@ function ShmCalculator() {
           subunits: ["m/s", "rad s^-1", "s", "rad"],
           setters: [setAmplitude, setOmega, setTime, setPhi],
           getters: [amplitude, omega, time, phi],
+          formula: "x = A sin(ωt + Φ)",
+          insertValues : `${amplitude}${SI["length"]} sin(${omega} * ${SI["ω"]}${time}${SI["time"]} + ${phi}${SI["φ"]})`,
+          givenValues : {
+              amplitude: amplitude,
+              ω: omega,
+              time: time,
+              φ: phi,
+          },
         };
       else if (choiceOsc === "pendulum")
         return {
@@ -430,6 +440,9 @@ function ShmCalculator() {
           getters: [mass, springConst],
         };
     };
+    
+    const givenValues = choice_data().givenValues;
+    const insertValues = choice_data().insertValues;
 
     return (
       <React.Fragment>
@@ -453,7 +466,12 @@ function ShmCalculator() {
             <Form.Control
               as="select"
               className="select-custom-res"
-              onChange={(e) => setChoiceOsc(e.target.value)}
+              onChange={(e) => 
+                {
+                  setChoiceOsc(e.target.value);
+                  setResult(null);
+                  setShowSolution(false)}
+                }
             >
               <option value="shm">General Equation: SHM</option>
               <option value="pendulum">Simple Pendulum </option>
@@ -538,8 +556,19 @@ function ShmCalculator() {
               }
               readOnly={choice_data().getters[3] === undefined ? true : false}
             />
-          </Form.Group>         
+          </Form.Group>
           
+          {showSolution ? (
+            <Form.Group className="mb-3" controlId="acceleration">
+              <Solution
+                givenValues={givenValues}
+                formula={choice_data().formula}
+                toFind={choice_data().name}
+                insertValues={insertValues}
+                result={result}
+              />
+            </Form.Group>
+          ) : null}
 
           <Form.Group className="mb-4">
             <Form.Control

--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -423,12 +423,17 @@ function ShmCalculator() {
         };
       else if (choiceOsc === "pendulum")
         return {
-          name: "Simple Pendulum",
+          name: "SimplePendulum",
           mainunit: "sec",
           quantities: ["Length of the pendulum"],
           subunits: ["m"],
           setters: [setLength],
           getters: [length],
+          formula: "T=2π√(l/g)",
+          insertValues : `2 * 3.14 √(${length}${SI["length"]} / 9.8)`,
+          givenValues : {
+              length : length,
+          },
         };
       else if (choiceOsc === "spring-mass")
         return {

--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -336,6 +336,8 @@ function ShmCalculator() {
     const [length, setLength] = useState(null);
     const [mass, setMass] = useState(null);
     const [springConst, setSpringConst] = useState(null);
+    const [showModal, setShowModal] = useState(false);
+    const [showSolution, setShowSolution] = useState(false);
 
     const handleClick = () => {
       let res;
@@ -343,17 +345,36 @@ function ShmCalculator() {
       const g = 9.8;
       switch (choiceOsc) {
         case "shm":
-          res =
+          if(omega !== null && time !== null && phi !== null){            
+            res =
             amplitude *
             Math.sin(
               ((omega * parseFloat(time) + parseFloat(phi)) * Math.PI) / 180
             );
+            setShowSolution(true);
+          }            
+          else {
+            setShowModal(true);
+            return;
+          }
           break;
         case "pendulum":
-          res = 2 * pi * Math.sqrt(length / g);
+          if(length !== null){
+            res = 2 * pi * Math.sqrt(length / g);
+          }           
+          else {
+            setShowModal(true);
+            return;
+          }
           break;
         case "spring-mass":
-          res = 2 * pi * Math.sqrt(mass / springConst);
+          if(mass !== null && springConst !== null){
+            res = 2 * pi * Math.sqrt(mass / springConst);
+          }          
+          else {
+            setShowModal(true);
+            return;
+          }
           break;
         default:
           res = null;
@@ -370,7 +391,8 @@ function ShmCalculator() {
       setAmplitude(null);
       setLength(null);
       setMass(null);
-      setSpringConst(null);
+      setSpringConst(null);      
+      setShowSolution(false);
       // setChoiceOsc("shm");
     };
 
@@ -411,6 +433,19 @@ function ShmCalculator() {
 
     return (
       <React.Fragment>
+        <Modal show={showModal} class="modal-dialog modal-dialog-centered">
+          <Modal.Header>
+            Please Enter all values to get Proper answer
+          </Modal.Header>
+          <Modal.Footer>
+            <Button
+              onClick={() => setShowModal(false)}
+              class="btn btn-primary btn-sm"
+            >
+              Close
+            </Button>
+          </Modal.Footer>
+        </Modal>
         <Form>
           {/* dropdown */}
           <Form.Group className="mb-4" controlId="choice">
@@ -503,7 +538,8 @@ function ShmCalculator() {
               }
               readOnly={choice_data().getters[3] === undefined ? true : false}
             />
-          </Form.Group>
+          </Form.Group>         
+          
 
           <Form.Group className="mb-4">
             <Form.Control

--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -443,6 +443,12 @@ function ShmCalculator() {
           subunits: ["Hz", "N/m"],
           setters: [setMass, setSpringConst],
           getters: [mass, springConst],
+          formula: "T=2π√(m/k)",
+          insertValues : `2 * 3.14 √(${mass}${SI["mass"]} / ${springConst}${SI["k"]})`,
+          givenValues : {
+              mass : mass,
+              k : springConst
+          },
         };
     };
     

--- a/funwithphysics/src/Components/Solution/allSIUnits.js
+++ b/funwithphysics/src/Components/Solution/allSIUnits.js
@@ -69,4 +69,5 @@ export const SI = {
   Stress: " Pa","Young's Modulus":" Pa","Bulk Modulus":" Pa","Young_Modulus":" Pa","Pressure":" Pa","pressure":" Pa",
   TempChange: " K","Temperature_Change":" K","tempcold":" K","temphot":" K","temperature":" K","Temperature (T)":" Kelvin","Temperature":" k",
   ExpansionCoeff:" K⁻¹","Expansion_Coeff":" K⁻¹",
+  SimplePendulum:"sec",
 };

--- a/funwithphysics/src/Components/Solution/allSIUnits.js
+++ b/funwithphysics/src/Components/Solution/allSIUnits.js
@@ -70,4 +70,5 @@ export const SI = {
   TempChange: " K","Temperature_Change":" K","tempcold":" K","temphot":" K","temperature":" K","Temperature (T)":" Kelvin","Temperature":" k",
   ExpansionCoeff:" K⁻¹","Expansion_Coeff":" K⁻¹",
   SimplePendulum:"sec",
+  k:"N/m"
 };

--- a/funwithphysics/src/Components/Solution/allSIUnits.js
+++ b/funwithphysics/src/Components/Solution/allSIUnits.js
@@ -31,7 +31,7 @@ export const SI = {
   "Gravitational Force": " Newton",
   area:" m²","Area":" m²","Area Expansion":" m²",
   Volume: " m³","Volume Expansion":" m³","volume": " m³",
-  displacement: " m",length:"m",width:"m","Final Length":" mm","Length Expansion":" m",
+  displacement: " m",length:"m",width:"m","Final Length":" mm","Length Expansion":" m","SHM":"m",
   angle: "°","Θ":"°",Theta:"°","Angle": "°","theta":"°","Brewster's angle" :"°",
   distance:" m",Radius:" m",R:" m",s:" m",r1:" m",r2:" m",H:" m","Distance":" m",λ:"m",Length: " m","Relative Length": "m","Wave Length": "m","Half_Length":" m","Image_Distance": " m","Object_Distance":" m","Focal Length":" m","Focal_Length":" m","Change_Length":" m","Change_Volume":" m³",
   microstates: "N",
@@ -68,5 +68,5 @@ export const SI = {
   SmallReading: " mm","Least Count":" mm","LeastCount":" mm" ,"Smallest_Reading":" mm","MSR":" mm","VSR":" mm","CSR":" mm","Least_Count":" mm","Distance_Moved":" mm","Pitch":" mm","Reading":" mm",
   Stress: " Pa","Young's Modulus":" Pa","Bulk Modulus":" Pa","Young_Modulus":" Pa","Pressure":" Pa","pressure":" Pa",
   TempChange: " K","Temperature_Change":" K","tempcold":" K","temphot":" K","temperature":" K","Temperature (T)":" Kelvin","Temperature":" k",
-  ExpansionCoeff:" K⁻¹","Expansion_Coeff":" K⁻¹"
+  ExpansionCoeff:" K⁻¹","Expansion_Coeff":" K⁻¹",
 };


### PR DESCRIPTION
## Related Issue

- Added solution part to different calculators in Oscillation section

Fixes: #448 

#### Describe the changes you've made

Added the solution steps for different calculators in Oscillation such as -

- General Equation SHM
- Simple Pendulum
- Spring Mass System

On switching from one calculator to a calculator the result is now set to null which was not previously there

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots
![image](https://user-images.githubusercontent.com/25982821/155991003-f1c184b5-4ae0-466a-a505-82ba15ccd524.png)
![image](https://user-images.githubusercontent.com/25982821/155991068-952771a2-d3ea-4dc1-9b55-7f5031784b27.png)
![image](https://user-images.githubusercontent.com/25982821/155991111-b3d6dbdf-b6d5-4978-b394-1ac42f7ee98d.png)


On switching from one result to another there result is now set to null 
![image](https://user-images.githubusercontent.com/25982821/155991190-5f556205-638d-43b4-b362-df9636cac411.png)


