### PR TITLE
fix: Remove extra fields and resolve the values in Waves section

### DIFF
--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -286,6 +286,11 @@ function ShmCalculator() {
                   ? true
                   : false
               }
+              className={
+                choice_data().name === 'time period'
+                ? "hide-text-box"
+                : ""
+              }
             />
           </Form.Group>
 

--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -228,7 +228,10 @@ function ShmCalculator() {
               onChange={(e) => {
                 setChoice(e.target.value);
                 setResult(null);
-                setShowSolution(false)}
+                setShowSolution(false);
+                setWave_length(null);
+                setVelocity(null);
+                setFreq(null);}
               }
             >
               <option value="Wave Length">λ : Wave Length</option>

--- a/funwithphysics/src/Components/PysicsStyles/physicscalculator.css
+++ b/funwithphysics/src/Components/PysicsStyles/physicscalculator.css
@@ -126,3 +126,7 @@
         padding: 1rem;
     }
 }
+
+.hide-text-box{
+    display: none!important;
+}


### PR DESCRIPTION
## Related Issue

- Removed the extra fields of the text box in the different calculators of Waves section
- Fixed the values are carrying forward while switching between two different calculators

Fixes: #457 

#### Describe the changes you've made

Will remove the extra fields in the different calculators of Waves section such as
- Wave Length
- Frequency
- Wave velocity
- energy
- time period

Some values are carried forward while switching into different calculators so that issue has been resolved

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x My changes generate no new warnings.

## Screenshots

https://user-images.githubusercontent.com/25982821/156244644-c9fc53be-472e-430f-b66c-f948dcdde0a3.mp4


