### PR TITLE
fix: Remove extra fields and resolve the values in Oscillation section

### DIFF
--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -68,6 +68,7 @@ function ShmCalculator() {
       if (choice === "Wave Length")
         return {
           name: "Wave Length",
+          optionname :"λ : Wave Length",
           mainunit: "m",
           quantities: ["Wave Velocity", "Frequency"],
           subunits: ["m/s", "Hz"],
@@ -83,6 +84,7 @@ function ShmCalculator() {
       else if (choice === "frequency")
         return {
           name: "frequency",
+          optionname :"f : frequency",
           mainunit: "Hz",
           quantities: ["Wave Length", "Wave Velocity"],
           subunits: ["m", "m/s"],
@@ -98,6 +100,7 @@ function ShmCalculator() {
       else if (choice === "time period")
         return {
           name: "time period",
+          optionname :"t: time period",
           mainunit: "s",
           quantities: ["Frequency"],
           subunits: ["Hz"],
@@ -112,6 +115,7 @@ function ShmCalculator() {
       else if (choice === "velocity")
         return {
           name: "Initial Velocity",
+          optionname :"v : wave velocity",
           mainunit: "m/s",
           quantities: ["Wave Length", "Frequency"],
           subunits: ["m", "Hz"],
@@ -127,6 +131,7 @@ function ShmCalculator() {
       else if (choice === "energy")
         return {
           name: "Energy",
+          optionname :"e: energy",
           mainunit: "Joule",
           quantities: ["Frequency", "Plank's constant"],
           subunits: ["Hz", "m² kg / s"],
@@ -234,6 +239,7 @@ function ShmCalculator() {
                 setFreq(null);}
               }
             >
+              <option selected hidden>{choice_data().optionname}</option>
               <option value="Wave Length">λ : Wave Length</option>
               <option value="frequency">f : frequency </option>
               <option value="velocity">v : wave velocity</option>

--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -545,6 +545,11 @@ function ShmCalculator() {
                   : choice_data().getters[1]
               }
               readOnly={choice_data().getters[1] === undefined ? true : false}
+              className={
+                choice_data().name === 'SimplePendulum'
+                ? "hide-text-box"
+                : ""
+              }
             />
           </Form.Group>
           <Form.Group className="mb-4">
@@ -563,6 +568,11 @@ function ShmCalculator() {
                   : choice_data().getters[2]
               }
               readOnly={choice_data().getters[2] === undefined ? true : false}
+              className={
+                choice_data().name === 'SimplePendulum'
+                ? "hide-text-box"
+                : ""
+              }
             />
           </Form.Group>
           <Form.Group className="mb-4">
@@ -581,6 +591,11 @@ function ShmCalculator() {
                   : choice_data().getters[3]
               }
               readOnly={choice_data().getters[3] === undefined ? true : false}
+              className={
+                choice_data().name === 'SimplePendulum'
+                ? "hide-text-box"
+                : ""
+              }
             />
           </Form.Group>
           

--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -496,7 +496,7 @@ function ShmCalculator() {
                 {
                   setChoiceOsc(e.target.value);
                   setResult(null);
-                  setShowSolution(false)}
+                  setShowSolution(false);}
                 }
             >
               <option value="shm">General Equation: SHM</option>
@@ -569,7 +569,7 @@ function ShmCalculator() {
               }
               readOnly={choice_data().getters[2] === undefined ? true : false}
               className={
-                choice_data().name === 'SimplePendulum'
+                choiceOsc === 'pendulum' || choiceOsc === 'spring-mass'
                 ? "hide-text-box"
                 : ""
               }
@@ -592,7 +592,7 @@ function ShmCalculator() {
               }
               readOnly={choice_data().getters[3] === undefined ? true : false}
               className={
-                choice_data().name === 'SimplePendulum'
+                choiceOsc === 'pendulum' || choiceOsc === 'spring-mass'
                 ? "hide-text-box"
                 : ""
               }

--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/ShmCalculator.js
@@ -496,7 +496,14 @@ function ShmCalculator() {
                 {
                   setChoiceOsc(e.target.value);
                   setResult(null);
-                  setShowSolution(false);}
+                  setShowSolution(false);
+                  setOmega(null);
+                  setTime(null);
+                  setPhi(null);
+                  setAmplitude(null);
+                  setLength(null);
+                  setMass(null);
+                  setSpringConst(null);}
                 }
             >
               <option value="shm">General Equation: SHM</option>

--- a/funwithphysics/src/Components/PysicsStyles/physicscalculator.css
+++ b/funwithphysics/src/Components/PysicsStyles/physicscalculator.css
@@ -130,5 +130,3 @@
 .hide-text-box{
     display: none!important;
 }
-.selected-option{
-}

--- a/funwithphysics/src/Components/PysicsStyles/physicscalculator.css
+++ b/funwithphysics/src/Components/PysicsStyles/physicscalculator.css
@@ -130,3 +130,5 @@
 .hide-text-box{
     display: none!important;
 }
+.selected-option{
+}


### PR DESCRIPTION
## Related Issue

- Removed the extra fields of the text box in the different calculators of the Oscillation section
- Fixed the values are carrying forward while switching between two different calculators
- Fixed the changing the value of the drop-down select button

Fixes: #458

#### Describe the changes you've made

Removed all the extra fields in the different calculators of the Oscillation section such as
- General Equation SHM
- Simple Pendulum
- Spring Mass System

Some values are carried forward while switching into different calculators so that issue has been resolved.
On pressing the reset button drop-down value is also set to default in the **Waves** calculator so that has been fixed.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots


https://user-images.githubusercontent.com/25982821/156387070-3b643011-c95d-4c1b-8b21-08bd0fa38238.mp4


