### PR TITLE
fix: Add solution part to different calculators in Progression section

### DIFF
--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -788,6 +788,7 @@ function Calculator() {
     const [showSolution1, setShowSolution1] = useState(false);
     const [showSolution2, setShowSolution2] = useState(false);
     const [showSumSolution1, setShowSumSolution1] = useState(false);
+    const [showSumSolution2, setShowSumSolution2] = useState(false);
 
     const givenValues1 = {
       first_term: n,
@@ -810,6 +811,13 @@ function Calculator() {
       n: nth,
     };
     const insertSumValues1 = `${n}/2 (2 * ${n} + (${nth}-1) * ${fr})`;
+
+    const givenSumValues2 = {
+      first_term: n,
+      xommon_ratio: fr,
+      n: nth,
+    };
+    const insertSumValues2 = `${n} * (${fr} * (${nth}-1) / (${fr} - 1))`;
 
 
     function handleChange(e) {
@@ -836,6 +844,7 @@ function Calculator() {
           res = Number(n) * Number(fr ** (nth - 1));
           s = (n * (fr ** nth - 1)) / (fr - 1);
           setShowSolution2(true);
+          setShowSumSolution2(true);
         }
         else {
           setShowModal(true);
@@ -852,6 +861,8 @@ function Calculator() {
       setSum(null);
       setShowSolution1(false);
       setShowSolution2(false);
+      setShowSumSolution1(false);
+      setShowSumSolution2(false);
     }
     const choiceData = () => {
       if (choice === "AP")
@@ -978,6 +989,19 @@ function Calculator() {
                     formula= "n/2 (2a+(n−1)d)"
                     toFind= "sum of numbers"
                     insertValues={insertSumValues1}
+                    result={sum}
+                    // constants={constants}
+                  />
+                </Form.Group>
+              ) : null}
+
+          {showSumSolution2 ? (
+                <Form.Group className="mb-3" controlId="acceleration">
+                  <Solution
+                    givenValues={givenSumValues2}
+                    formula= "a(rn−1)r−1"
+                    toFind= "sum of numbers"
+                    insertValues={insertSumValues2}
                     result={sum}
                     // constants={constants}
                   />

--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
-import { Form, Button } from "react-bootstrap";
+import { Form, Button, Modal } from "react-bootstrap";
 import { Helmet } from "react-helmet";
 import Navbar from "../../Navbar/Navbar";
 import { useParams } from "react-router";
 import "./Calculator.css";
 import { useEffect } from "react";
+import Solution from "../../Solution/Solution";
 
 function Calculator() {
   let { topic } = useParams();
@@ -783,6 +784,18 @@ function Calculator() {
     const [fr, setFR] = useState(null);
     const [nth, setNth] = useState(null);
     const [sum, setSum] = useState(null);
+    const [showModal, setShowModal] = useState(false);
+    const [showSolution1, setShowSolution1] = useState(false);
+
+    const givenValues1 = {
+      first_term: n,
+      d: fr,
+      n: nth,
+    };
+
+    const insertValues1 = `${n} + ${fr} * (${nth}-1)`;
+
+
     function handleChange(e) {
       reset();
       setChoice(e.target.value);
@@ -790,10 +803,18 @@ function Calculator() {
     }
     const calcResult = () => {
       let res, s;
+      
       if (choice === "AP") {
-        res = Number(n) + Number(fr * (nth - 1));
-        s = (nth / 2) * (Number(2 * n) + Number(fr * (nth - 1)));
-      } else if (choice === "GP") {
+        if(n !== null && fr !== null && nth !== null){          
+          res = Number(n) + Number(fr * (nth - 1));
+          s = (nth / 2) * (Number(2 * n) + Number(fr * (nth - 1)));
+          setShowSolution1(true);
+        }
+        else {
+          setShowModal(true);
+        }
+      } 
+      else if (choice === "GP") {
         res = Number(n) * Number(fr ** (nth - 1));
         s = (n * (fr ** nth - 1)) / (fr - 1);
       }
@@ -806,6 +827,7 @@ function Calculator() {
       setFR(null);
       setNth(null);
       setSum(null);
+      setShowSolution1(false);
     }
     const choiceData = () => {
       if (choice === "AP")
@@ -813,6 +835,7 @@ function Calculator() {
           name: "Arithmetic Progression",
           quantities: ["First Number", "Common diffrence"],
           disable: true,
+          formula: "a + d * (n-1)",
         };
       else if (choice === "GP") {
         return {
@@ -822,7 +845,20 @@ function Calculator() {
       }
     };
     return (
-      <>
+      <>      
+        <Modal show={showModal} class="modal-dialog modal-dialog-centered">
+            <Modal.Header>
+              Please Enter all values to get Proper answer
+            </Modal.Header>
+            <Modal.Footer>
+              <Button
+                onClick={() => setShowModal(false)}
+                class="btn btn-primary btn-sm"
+              >
+                Close
+              </Button>
+            </Modal.Footer>
+          </Modal>
         <Form>
           {/* dropdown */}
           <Form.Group className="mb-4" controlId="choice">
@@ -872,6 +908,22 @@ function Calculator() {
               value={nth === null ? "" : nth}
             />
           </Form.Group>
+
+          
+          {showSolution1 ? (
+                <Form.Group className="mb-3" controlId="acceleration">
+                  <Solution
+                    givenValues={givenValues1}
+                    formula={choiceData().formula}
+                    toFind={choiceData().name}
+                    insertValues={insertValues1}
+                    result={result}
+                    // constants={constants}
+                  />
+                </Form.Group>
+              ) : null}
+            
+
           <Form.Group className="mb-4">
             <Form.Label>Number at {nth ? nth : "nth"} position</Form.Label>
             <Form.Control

--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -787,6 +787,7 @@ function Calculator() {
     const [showModal, setShowModal] = useState(false);
     const [showSolution1, setShowSolution1] = useState(false);
     const [showSolution2, setShowSolution2] = useState(false);
+    const [showSumSolution1, setShowSumSolution1] = useState(false);
 
     const givenValues1 = {
       first_term: n,
@@ -802,6 +803,13 @@ function Calculator() {
       n: nth,
     };
     const insertValues2 = `${n} * ${fr} ^ (${nth}-1)`;
+    
+    const givenSumValues1 = {
+      first_term: n,
+      d: fr,
+      n: nth,
+    };
+    const insertSumValues1 = `${n}/2 (2 * ${n} + (${nth}-1) * ${fr})`;
 
 
     function handleChange(e) {
@@ -817,6 +825,7 @@ function Calculator() {
           res = Number(n) + Number(fr * (nth - 1));
           s = (nth / 2) * (Number(2 * n) + Number(fr * (nth - 1)));
           setShowSolution1(true);
+          setShowSumSolution1(true);
         }
         else {
           setShowModal(true);
@@ -961,6 +970,21 @@ function Calculator() {
               placeholder={result === null ? "Result" : result}
             />
           </Form.Group>
+
+          {showSumSolution1 ? (
+                <Form.Group className="mb-3" controlId="acceleration">
+                  <Solution
+                    givenValues={givenSumValues1}
+                    formula= "n/2 (2a+(n−1)d)"
+                    toFind= "sum of numbers"
+                    insertValues={insertSumValues1}
+                    result={sum}
+                    // constants={constants}
+                  />
+                </Form.Group>
+              ) : null}
+
+
           <Form.Group className="mb-4">
             <Form.Label>
               Sum of numbers till {nth ? nth : "nth"} position

--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -786,6 +786,7 @@ function Calculator() {
     const [sum, setSum] = useState(null);
     const [showModal, setShowModal] = useState(false);
     const [showSolution1, setShowSolution1] = useState(false);
+    const [showSolution2, setShowSolution2] = useState(false);
 
     const givenValues1 = {
       first_term: n,
@@ -794,6 +795,13 @@ function Calculator() {
     };
 
     const insertValues1 = `${n} + ${fr} * (${nth}-1)`;
+
+    const givenValues2 = {
+      first_term: n,
+      d: fr,
+      n: nth,
+    };
+    const insertValues2 = `${n} * ${fr} ^ (${nth}-1)`;
 
 
     function handleChange(e) {
@@ -815,8 +823,14 @@ function Calculator() {
         }
       } 
       else if (choice === "GP") {
-        res = Number(n) * Number(fr ** (nth - 1));
-        s = (n * (fr ** nth - 1)) / (fr - 1);
+        if(n !== null && fr !== null && nth !== null){
+          res = Number(n) * Number(fr ** (nth - 1));
+          s = (n * (fr ** nth - 1)) / (fr - 1);
+          setShowSolution2(true);
+        }
+        else {
+          setShowModal(true);
+        }
       }
       setResult(res);
       setSum(s);
@@ -828,6 +842,7 @@ function Calculator() {
       setNth(null);
       setSum(null);
       setShowSolution1(false);
+      setShowSolution2(false);
     }
     const choiceData = () => {
       if (choice === "AP")
@@ -841,6 +856,7 @@ function Calculator() {
         return {
           name: "Geometric Progression",
           quantities: ["First Number", "Common ratio"],
+          formula:"a * r ^ (n-1)",
         };
       }
     };
@@ -917,6 +933,19 @@ function Calculator() {
                     formula={choiceData().formula}
                     toFind={choiceData().name}
                     insertValues={insertValues1}
+                    result={result}
+                    // constants={constants}
+                  />
+                </Form.Group>
+              ) : null}
+
+          {showSolution2 ? (
+                <Form.Group className="mb-3" controlId="acceleration">
+                  <Solution
+                    givenValues={givenValues2}
+                    formula={choiceData().formula}
+                    toFind={choiceData().name}
+                    insertValues={insertValues2}
                     result={result}
                     // constants={constants}
                   />


### PR DESCRIPTION
## Related Issue

- Added solution part to different calculators in Progression section

Fixes: #505 

#### Describe the changes you've made

Added the solution steps for different calculators in Progression such as -
 - Arithmetic Progression
 - Geometric Progression
 
Added Solution steps for the **sum of n numbers** for both the calculators.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

https://user-images.githubusercontent.com/25982821/156796123-96e8f5ab-53a2-46e6-803f-ca43b6124fd6.mp4


