### PR TITLE
Resolved issue related to topic-card overlapping navbar on hover.

### DIFF
--- a/funwithphysics/src/Components/LearnMore/styles.css
+++ b/funwithphysics/src/Components/LearnMore/styles.css
@@ -317,5 +317,5 @@ a.plus:hover {
   cursor: pointer;
   transform: scale(1.1);
   box-shadow: none;
-  z-index:5;
+  z-index:2;
 }

--- a/funwithphysics/src/Components/Navbar/Navbar.js
+++ b/funwithphysics/src/Components/Navbar/Navbar.js
@@ -49,7 +49,7 @@ const Navbar = () => {
   };
   return (
     <React.Fragment>
-      <nav className='navbar navbar-expand-lg navbar-light bg-light pt-3' style = {{position:'sticky',top:'0',zIndex:'1'}}>
+      <nav className='navbar navbar-expand-lg navbar-light bg-light pt-3' style = {{position:'sticky',top:'0',zIndex:'3'}}>
         <p className='navbar-brand'>
           <button
             className='navbar-toggler'


### PR DESCRIPTION
## Related Issue

- Info about Issue or bug : The Topic cards in Explore under Learn section overlaps with the Navbar on hover and also the same issue can be seen with the behaviour of dropdown menu. The Navbar should not be under the card at any time.

Fixes: #498 

#### Describe the changes you've made

Changed the z-index of Topic card to 2 and changed the z-index of navbar to 3 to achieve relative stacking.  

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| ![image](https://user-images.githubusercontent.com/59263190/156831990-bb552de1-64de-4897-9637-6d972a98be51.png)| ![image](https://user-images.githubusercontent.com/59263190/156832304-c3cc171f-d0a0-4314-a542-f22701817e59.png)|
| ![image](https://user-images.githubusercontent.com/59263190/156832460-82e75d42-9b62-4dfb-9d23-c3ed4f2c48ce.png)|![image](https://user-images.githubusercontent.com/59263190/156832552-906ba651-1bcc-48a5-97af-4fe30fed483e.png)|