### PR TITLE
Add steps in Poiseuille's law calculator 

### DIFF
--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/fluidmechanics_Calculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/fluidmechanics_Calculator.js
@@ -702,7 +702,7 @@ function FluidCalculator() {
          }
          else{
         res =
-          (8 * viscosity * length * flowrate) / (Math.PI * Math.pow(radius, 4));
+          (8 * viscosity * length * flowrate) / (Math.PI * Math.pow(radius, 4)) + " pascal" ;
           setShowSolutionPressure(true);
           setShowSolutionFlowrate(false); } }
       else if (choice === "flowrate") {  if(viscosity ===null || length===null|| pressurediff===null||radius===null)
@@ -711,7 +711,7 @@ function FluidCalculator() {
        }else{
         res =
           (pressurediff * Math.PI * Math.pow(radius, 4)) /
-          (8 * viscosity * length);
+          (8 * viscosity * length) + " m³/s";
           setShowSolutionFlowrate(true);
           setShowSolutionPressure(false);
       }}
@@ -731,7 +731,7 @@ function FluidCalculator() {
       if (choice === "pressure")
         return {
           name: "Pressure",
-          mainunit: "pascal",
+          mainunit: " ",
           quantities: [
             "Viscosity of fluid",
             "Length of pipe",
@@ -746,7 +746,7 @@ function FluidCalculator() {
       else if (choice === "flowrate")
         return {
           name: "Volumetric flow Rate",
-          mainunit: "m³/s",
+          mainunit: " ",
           quantities: [
             "Viscosity of fluid",
             "Length of pipe",

--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/fluidmechanics_Calculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/fluidmechanics_Calculator.js
@@ -676,8 +676,19 @@ function FluidCalculator() {
     const [pressurediff, setPressurediff] = useState(null);
     const [choice, setChoice] = useState("pressure");
     const [pi, setPi] = useState(Math.PI);
-
-    function handleChange(e) {
+    const [showModal, setShowModal] = useState(false);
+    const [showSolutionPressure, setShowSolutionPressure] = useState(false);
+    const [showSolutionFlowrate, setShowSolutionFlowrate] = useState(false);
+    const givenValuesPressure={viscosity: viscosity,length:length,
+      flowrate:flowrate,radius:radius
+    }
+    const givenValuesFlowrate={viscosity: viscosity,length:length,
+      pressure_difference:pressurediff,radius:radius
+    }
+   const insertValuesPressure=`(8* ${viscosity} * ${length}*${flowrate})/ π* ${radius}⁴`
+   const insertValuesFlowrate=`(${pressurediff} *π *${radius}⁴)/ 8 * ${viscosity}* ${length}`
+  
+   function handleChange(e) {
       setChoice(e.target.value);
       choiceData();
     }
@@ -685,13 +696,25 @@ function FluidCalculator() {
     const calcResult = () => {
       let res;
       if (choice === "pressure") {
+        if(viscosity ===null || length===null|| flowrate===null||radius===null)
+      
+          { setShowModal(true);
+         }
+         else{
         res =
           (8 * viscosity * length * flowrate) / (Math.PI * Math.pow(radius, 4));
-      } else if (choice === "flowrate") {
+          setShowSolutionPressure(true);
+          setShowSolutionFlowrate(false); } }
+      else if (choice === "flowrate") {  if(viscosity ===null || length===null|| pressurediff===null||radius===null)
+      
+        { setShowModal(true);
+       }else{
         res =
           (pressurediff * Math.PI * Math.pow(radius, 4)) /
           (8 * viscosity * length);
-      }
+          setShowSolutionFlowrate(true);
+          setShowSolutionPressure(false);
+      }}
       setResult(res);
     };
 
@@ -735,10 +758,23 @@ function FluidCalculator() {
           setters: [setViscosity, setLength, setPressurediff, setRadius, setPi],
           getters: [viscosity, length, pressurediff, radius, pi],
         };
+       
     };
 
     return (
-      <>
+      <><Modal show={showModal} class="modal-dialog modal-dialog-centered">
+      <Modal.Header>
+        Please enter the numbers to get correct answer.
+      </Modal.Header>
+      <Modal.Footer>
+        <Button
+          onClick={() => setShowModal(false)}
+          class="btn btn-primary btn-sm"
+        >
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
         <Form>
           {/* dropdown */}
           <Form.Group className="mb-4" controlId="choice">
@@ -819,6 +855,30 @@ function FluidCalculator() {
               }
             />
           </Form.Group>
+          {showSolutionPressure ? (
+            <Form.Group className="mb-3" controlId="acceleration">
+              <Solution
+                givenValues={givenValuesPressure}
+                formula="Δp = 8μLQ/πR⁴"
+                toFind="Pressure Difference"
+                insertValues={insertValuesPressure}
+                result={result}
+                // constants={constants}
+              />
+            </Form.Group>
+          ) : null}
+           {showSolutionFlowrate ? (
+            <Form.Group className="mb-3" controlId="acceleration">
+              <Solution
+                givenValues={givenValuesFlowrate}
+                formula="Q =ΔpπR⁴/8μL"
+                toFind="Volumetric Flow Rate"
+                insertValues={insertValuesFlowrate}
+                result={result}
+                // constants={constants}
+              />
+            </Form.Group>
+          ) : null}
           <Form.Group className="mb-4">
             <Form.Control
               readOnly

--- a/funwithphysics/src/Components/Solution/allSIUnits.js
+++ b/funwithphysics/src/Components/Solution/allSIUnits.js
@@ -31,6 +31,7 @@ export const SI = {
   "Gravitational Force": " Newton",
   area:" m²","Area":" m²","Area Expansion":" m²","Area1": "m²","Area2": "m²",
   Volume: " m³","Volume Expansion":" m³","volume": " m³",
+  viscosity:"pascal-second", flowrate:" m³/s", radius:"m", pressure_difference:"pascal",
   displacement: " m",length:"m",width:"m","Final Length":" mm","Length Expansion":" m","SHM":"m",
   angle: "°","Θ":"°",Theta:"°","Angle": "°","theta":"°","Brewster's angle" :"°",
   distance:" m",Radius:" m",R:" m",s:" m",r1:" m",r2:" m",H:" m","Distance":" m",λ:"m",Length: " m","Relative Length": "m","Wave Length": "m","Half_Length":" m","Image_Distance": " m","Object_Distance":" m","Focal Length":" m","Focal_Length":" m","Change_Length":" m","Change_Volume":" m³",


### PR DESCRIPTION
## Related Issue

- Info about Issue or bug

Fixes: #540 

#### Describe the changes you've made

I have added the steps for the field in the Poiseuille's law calculator.
I have also added the modal which will appear if the user leaves the input field empty.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
|
![pc2](https://user-images.githubusercontent.com/93239528/163578331-086ef581-a949-494e-8cbb-0b99f6454129.png)
original
 |<b>
![pc3](https://user-images.githubusercontent.com/93239528/163578366-d00453a1-f532-4b3a-9235-7d162d06cfca.png)

 updated</b> |

## Video


https://user-images.githubusercontent.com/93239528/163578207-ee6f2edd-a892-40d6-8f0a-15d029b37480.mp4



@Amit366  Please review this PR.