### PR TITLE
Fix: scrollToTop button bug

### DIFF
--- a/funwithphysics/src/Components/Home/Home.js
+++ b/funwithphysics/src/Components/Home/Home.js
@@ -37,8 +37,8 @@ const bookReaderStyle = {
     const position = window.pageYOffset
     //console.log(position)
     if (position === 0)
-      backToTopRef.current.style.display = 'none'
-    else backToTopRef.current.style.display = 'block'
+    backToTopRef.current!==null&&(backToTopRef.current.style.display = 'none')
+    else backToTopRef.current!==null&&(backToTopRef.current.style.display = 'block')
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Related Issue

- Info about Issue or bug

Fixes: #604 

Added null checking on `backToTopRef.current` before changing its `.style.display`.


## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| ![image](https://user-images.githubusercontent.com/74536497/161843409-234d39e5-5376-4c6e-9016-51532025fff6.png) | <b>![image](https://user-images.githubusercontent.com/74536497/161843472-7d4535b7-73e3-4891-bf31-a526974050b0.png)
</b> |
