### PR TITLE
Reset in Poiseuille's law calculator

### DIFF
--- a/funwithphysics/src/Components/Classical_Mechanics/Topics/fluidmechanics_Calculator.js
+++ b/funwithphysics/src/Components/Classical_Mechanics/Topics/fluidmechanics_Calculator.js
@@ -725,6 +725,8 @@ function FluidCalculator() {
       setFlowrate(null);
       setRadius(null);
       setPressurediff(null);
+      setShowSolutionFlowrate(false);
+      setShowSolutionPressure(false);
     }
 
     const choiceData = () => {


### PR DESCRIPTION
## Related Issue

- The reset button was not working

Fixes: #540 

#### Describe the changes you've made

The reset button is working fine now.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Screenshots/ Videos


https://user-images.githubusercontent.com/93239528/163711175-5f91df9a-e003-4d3f-9cd5-29cccc4fbd2f.mp4

Continuation of #615 PR


