### PR TITLE
added modal to handle error in exponent calculator

### DIFF
--- a/funwithphysics/src/Components/Algebra/Topic/Calculator.js
+++ b/funwithphysics/src/Components/Algebra/Topic/Calculator.js
@@ -1367,6 +1367,7 @@ function Calculator() {
     });
     const [x, setX] = useState(null);
     const [n, setN] = useState(null);
+    const [showModal, setShowModal] = useState(false);
 
     useEffect(() => {
       if (choice === "Power") {
@@ -1397,7 +1398,7 @@ function Calculator() {
     const calcResult = () => {
       let res = 1;
       var y;
-      if (choice === "Power"){
+      if (choice === "Power" && x!==null && n!==null ){
            res = Math.pow(x, n);
            var x_ = `${x} `
             y= x_.repeat(n);
@@ -1406,11 +1407,23 @@ function Calculator() {
             // console.log(y)
             y= `${y} = ${res}`
       }
-      else if (choice === "SquareRoot"){
+      else if(choice === "Power" && (x===null || n===null) ){
+        setShowModal(true);
+        return
+      }
+      else if (choice === "SquareRoot" && x!==null){
         res = Math.sqrt(x);
         y= `b  x b = ${x} \n Therefore, b =${res}`
       } 
-      else {
+      else if(choice === "SquareRoot" && x===null  ){
+        setShowModal(true);
+        return
+      }
+      else if(choice === "CubeRoot" && x===null){
+        setShowModal(true);
+        return
+      }
+      else{
         res = Math.cbrt(x);
         y = `b  x b x b = ${x} \n Therefore, b =${res}`
       }
@@ -1424,6 +1437,8 @@ function Calculator() {
       setResult(null);
       setExplanation(null)
       setChoice(e.target.value);
+      if (e.target.value === "Power") setN(null);
+     
     };
 
     function reset() {
@@ -1435,6 +1450,20 @@ function Calculator() {
 
     return (
       <>
+      {/* error modal for incomplete values */}
+      <Modal show={showModal} class="modal-dialog modal-dialog-centered">
+          <Modal.Header>
+            Please Enter all values to get Proper answer
+          </Modal.Header>
+          <Modal.Footer>
+            <Button
+              onClick={() => setShowModal(false)}
+              class="btn btn-primary btn-sm"
+            >
+              Close
+            </Button>
+          </Modal.Footer>
+        </Modal>
         <Form>
           <Form.Group className="mb-4" controlId="choice">
             <Form.Label>Select the type of calculation</Form.Label>


### PR DESCRIPTION
## Related Issue

- This is an update to PR#611  to ensure proper error handling

Fixes: #564 

#### Describe the changes you've made

I added a modal to inform user when one of the inputs required is missing

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x ] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [x ] My changes generate no new warnings.

## Screenshots
![funwithscience shot](https://user-images.githubusercontent.com/67394368/163730017-6b17cacc-9a4c-42c4-a29f-bc11aabad6c9.png)
