### PR TITLE
feat: Add Home button after quiz ends

### DIFF
--- a/funwithphysics/src/Components/Quiz/mathsquiz.js
+++ b/funwithphysics/src/Components/Quiz/mathsquiz.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import "./Quiz.css";
 import { Helmet } from "react-helmet";
+import { Link } from "react-router-dom";
 import Button from 'react-bootstrap/Button';
 
 const MathsQuiz = () => {
@@ -135,6 +136,9 @@ const MathsQuiz = () => {
                 <button onClick={()=>replay()} class="btn btn-success">
                   Play Again
                 </button>
+                <Link to='/'>
+                  <button className="btn btn-primary" style={{ margin: '20px 0px' }}>Home</button>
+                </Link>      
               </div>
             </div>
           </div>

--- a/funwithphysics/src/Components/Quiz/physicsquiz.js
+++ b/funwithphysics/src/Components/Quiz/physicsquiz.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import "./Quiz.css";
 import { Helmet } from "react-helmet";
 
@@ -239,6 +240,9 @@ const PhysicsQuiz = () => {
                 <button onClick={()=>replay()} class="btn btn-success">
                   Play Again
                 </button>
+                <Link to='/' >
+                  <button className="btn btn-primary" style={{ margin: '20px 0px' }}>Home</button>
+                </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Related Issue

When any quiz ends, the user doesn't get any navigation ideas, so a home button has been added.

Fixes: #574 

#### Describe the changes you've made

Added a Home button after quiz ends

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

### Original

![original](https://user-images.githubusercontent.com/74665996/192209865-d73a8ca8-7e14-4b48-80d8-cc1b6dceacf0.png)


### Updated

![updated](https://user-images.githubusercontent.com/74665996/192209889-3b1eb56c-926b-47c3-ad79-4453eb2ad537.png)
